### PR TITLE
Rename "watched" to "permit" zones.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ with San Francisco as the initial implementation.
 * **Parking Detection**:
     * Triggered by **Bluetooth Disconnection** from a user-selected device (Car Audio).
     * Implemented in `BluetoothConnectionReceiver` using `goAsync` for immediate execution.
-    * Fetches high-accuracy location and matches it against the user's **Watchlist** (< 30m
+    * Fetches high-accuracy location and matches it against the user's **Permit Zone** (< 30m
       distance).
 * **Reminders**:
     * Users "watch" streets by selecting an RPP (Residential Parking Permit) zone.
@@ -59,7 +59,7 @@ core/data/
 app/                    # Application entry point, AppGraph DI wiring
 feature/
 ├── map/                # Map view showing parking spots (Google Maps)
-├── reminders/          # Watchlist, reminder settings, ParkingManager
+├── reminders/          # Permit zone management, reminder settings, ParkingManager
 └── onboarding/         # Setup flow (permissions, Bluetooth device selection)
 core/
 ├── model/              # Domain entities (ParkingSpot, SweepingSchedule, Geometry)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ ParkBuddy is a smart Android application designed to simplify urban parking. It 
 
 - **Automated Parking Detection:** Automatically records your parking location when your car's Bluetooth disconnects.
 - **RPP Zone Integration:** Syncs with city data to provide up-to-date information on parking restrictions.
-- **Parking Watchlist:** Monitor specific streets and receive notifications before restrictions take effect.
+- **Permit Zone Management:** Monitor your residential permit zone and receive notifications before restrictions take effect.
 - **Interactive Map:** Visualize your parked location and nearby parking zones.
 - **Modern Stack:** Built with Kotlin, Jetpack Compose, and a modular architecture.
 

--- a/app/src/main/java/dev/bongballe/parkbuddy/MainActivity.kt
+++ b/app/src/main/java/dev/bongballe/parkbuddy/MainActivity.kt
@@ -53,7 +53,7 @@ import dev.parkbuddy.feature.map.MapScreen
 import dev.parkbuddy.feature.onboarding.PermissionChecker
 import dev.parkbuddy.feature.onboarding.bluetooth.BluetoothDeviceSelectionScreen
 import dev.parkbuddy.feature.onboarding.permission.RequestPermissionScreen
-import dev.parkbuddy.feature.reminders.watchlist.WatchlistScreen
+import dev.parkbuddy.feature.reminders.permitzone.PermitZoneScreen
 import dev.parkbuddy.feature.settings.SettingsScreen
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesIntoMap
@@ -176,7 +176,7 @@ private fun MainScreen(
 
           NavigationBarItem(
             icon = { Icon(imageVector = Icons.Default.Visibility, contentDescription = null) },
-            label = { Text("WATCHED") },
+            label = { Text("MY ZONE") },
             selected = selectedTab == 1,
             onClick = { onTabSelected(1) },
           )
@@ -193,7 +193,7 @@ private fun MainScreen(
       Box(modifier = Modifier.padding(paddingValues).consumeWindowInsets(paddingValues)) {
         when (selectedTab) {
           0 -> MapScreen()
-          1 -> WatchlistScreen()
+          1 -> PermitZoneScreen()
           2 -> SettingsScreen(onNavigateToBluetooth = onNavigateToBluetooth)
         }
       }

--- a/core/data/api/src/main/kotlin/dev/bongballe/parkbuddy/data/repository/ParkingManager.kt
+++ b/core/data/api/src/main/kotlin/dev/bongballe/parkbuddy/data/repository/ParkingManager.kt
@@ -42,14 +42,14 @@ class ParkingManager(
         return
       }
 
-      val watchedSpots = repository.getSpotsByZone(userZone).first()
-      if (watchedSpots.isEmpty()) {
-        analyticsTracker.logEvent("parking_event_empty_watchlist", mapOf("zone" to userZone))
+      val permitSpots = repository.getSpotsByZone(userZone).first()
+      if (permitSpots.isEmpty()) {
+        analyticsTracker.logEvent("parking_event_empty_permit_zone", mapOf("zone" to userZone))
         notificationManager.sendParkingMatchFailureNotification()
         return
       }
 
-      val matchingSpot = findMatchingSpot(location, watchedSpots)
+      val matchingSpot = findMatchingSpot(location, permitSpots)
 
       if (matchingSpot != null) {
         analyticsTracker.logEvent("parking_event_success")

--- a/core/data/sf-impl/src/main/java/dev/bongballe/parkbuddy/data/sf/database/ParkingDao.kt
+++ b/core/data/sf-impl/src/main/java/dev/bongballe/parkbuddy/data/sf/database/ParkingDao.kt
@@ -21,9 +21,9 @@ import kotlinx.coroutines.flow.Flow
  * 3. Data is stored via [insertSpots] and [insertSchedules]
  * 4. UI observes data via Flow-returning methods
  *
- * ## Watched Streets
- * Streets are "watched" based on user's selected RPP zone ([UserPreferencesEntity.rppZone]). Use
- * [getSpotsByZone] to get all watched spots for reminder scheduling.
+ * ## Permit Streets
+ * Streets are managed based on user's selected RPP zone ([UserPreferencesEntity.rppZone]). Use
+ * [getSpotsByZone] to get all permit spots for reminder scheduling.
  *
  * @see ParkingSpotEntity
  * @see SweepingScheduleEntity
@@ -43,7 +43,7 @@ interface ParkingDao {
   fun getAllSpots(): Flow<List<PopulatedParkingSpot>>
 
   /**
-   * Get parking spots in a specific RPP zone with their sweeping schedules. Used to get "watched"
+   * Get parking spots in a specific RPP zone with their sweeping schedules. Used to get permit
    * streets when user has selected a zone.
    *
    * @param zone RPP zone letter (e.g., "N", "A")
@@ -64,7 +64,7 @@ interface ParkingDao {
   @Query("SELECT * FROM parking_spots WHERE rppArea = :zone")
   fun getSpotEntitiesByZone(zone: String): Flow<List<ParkingSpotEntity>>
 
-  /** Count spots in a zone. Used for "X streets watched" display. */
+  /** Count spots in a zone. Used for "X streets managed" display. */
   @Query("SELECT COUNT(*) FROM parking_spots WHERE rppArea = :zone")
   fun countSpotsByZone(zone: String): Flow<Int>
 

--- a/core/data/sf-impl/src/main/java/dev/bongballe/parkbuddy/data/sf/database/entity/UserPreferencesEntity.kt
+++ b/core/data/sf-impl/src/main/java/dev/bongballe/parkbuddy/data/sf/database/entity/UserPreferencesEntity.kt
@@ -10,7 +10,7 @@ import androidx.room.PrimaryKey
  *
  * @property id Always 1 (single row pattern)
  * @property rppZone User's selected Residential Parking Permit zone (e.g., "N", "A"). When set, all
- *   parking spots in this zone are "watched" for cleaning reminders. Null means no zone selected.
+ *   streets in this zone are managed for cleaning reminders. Null means no zone selected.
  * @property reminderMinutes Comma-separated list of reminder times in minutes before cleaning.
  *   e.g., "60,1440" means remind 1 hour and 24 hours before. Empty string means no reminders
  *   configured.

--- a/core/model/src/main/kotlin/dev/bongballe/parkbuddy/model/ParkedLocation.kt
+++ b/core/model/src/main/kotlin/dev/bongballe/parkbuddy/model/ParkedLocation.kt
@@ -4,8 +4,16 @@ import kotlinx.datetime.Instant
 import kotlinx.serialization.Serializable
 
 @Serializable
+enum class ParkingType {
+  PERMIT,
+  TIMED,
+  UNRESTRICTED
+}
+
+@Serializable
 data class ParkedLocation(
   val spotId: String,
   val location: Location,
   val parkedAt: Instant,
+  val parkingType: ParkingType = ParkingType.PERMIT,
 )

--- a/feature/map/src/main/java/dev/parkbuddy/feature/map/MapScreen.kt
+++ b/feature/map/src/main/java/dev/parkbuddy/feature/map/MapScreen.kt
@@ -54,10 +54,10 @@ import kotlinx.coroutines.tasks.await
 fun MapScreen(modifier: Modifier = Modifier, viewModel: MapViewModel = metroViewModel()) {
   val state by viewModel.stateFlow.collectAsState()
   val spots = state.spots
-  val watchedSpots = state.watchedSpots
+  val permitSpots = state.permitSpots
   val parkedLocation = state.parkedLocation
 
-  val watchedSpotIds = remember(watchedSpots) { watchedSpots.map { it.objectId }.toSet() }
+  val permitSpotIds = remember(permitSpots) { permitSpots.map { it.objectId }.toSet() }
 
   // Pre-compute LatLng points for all spots once
   val spotsWithPoints =
@@ -132,11 +132,11 @@ fun MapScreen(modifier: Modifier = Modifier, viewModel: MapViewModel = metroView
     ) {
       visibleSpots.forEach { (spot, points) ->
         if (points.isNotEmpty()) {
-          val isWatched = spot.objectId in watchedSpotIds
+          val isInPermitZone = spot.objectId in permitSpotIds
           Polyline(
             points = points,
-            color = if (isWatched) SageGreen else WildIris,
-            width = if (isWatched) 12f else 8f,
+            color = if (isInPermitZone) SageGreen else WildIris,
+            width = if (isInPermitZone) 12f else 8f,
             clickable = true,
             onClick = { selectedSpot = spot },
           )
@@ -167,7 +167,7 @@ fun MapScreen(modifier: Modifier = Modifier, viewModel: MapViewModel = metroView
       ) {
         SpotDetailContent(
           spot = it,
-          isWatched = it.objectId in watchedSpotIds,
+          isInPermitZone = it.objectId in permitSpotIds,
           onParkHere = {
             viewModel.parkHere(it)
             selectedSpot = null

--- a/feature/map/src/main/java/dev/parkbuddy/feature/map/MapViewModel.kt
+++ b/feature/map/src/main/java/dev/parkbuddy/feature/map/MapViewModel.kt
@@ -39,7 +39,7 @@ class MapViewModel(
 
   data class State(
     val spots: List<ParkingSpot>,
-    val watchedSpots: List<ParkingSpot>,
+    val permitSpots: List<ParkingSpot>,
     val parkedLocation: Triple<ParkedLocation, ParkingSpot, List<ReminderMinutes>>?,
     val shouldShowParkedLocationBottomSheet: Boolean,
   )
@@ -59,13 +59,13 @@ class MapViewModel(
         flow5 = shouldShowParkedLocationBottomSheet,
         transform = {
           parkingSpots,
-          watchedSpots,
+          permitSpots,
           parkedLocation,
           reminder,
           shouldShowParkedLocationBottomSheet ->
           State(
             spots = parkingSpots,
-            watchedSpots = watchedSpots,
+            permitSpots = permitSpots,
             parkedLocation =
               parkedLocation?.let {
                 val spot = parkingSpots.firstOrNull { it.objectId == parkedLocation.spotId }
@@ -81,7 +81,7 @@ class MapViewModel(
         initialValue =
           State(
             spots = emptyList(),
-            watchedSpots = emptyList(),
+            permitSpots = emptyList(),
             parkedLocation = null,
             shouldShowParkedLocationBottomSheet = false,
           ),

--- a/feature/map/src/main/java/dev/parkbuddy/feature/map/SpotDetailContent.kt
+++ b/feature/map/src/main/java/dev/parkbuddy/feature/map/SpotDetailContent.kt
@@ -37,7 +37,7 @@ import kotlinx.datetime.LocalTime
 @Composable
 internal fun SpotDetailContent(
   spot: ParkingSpot,
-  isWatched: Boolean,
+  isInPermitZone: Boolean,
   onParkHere: () -> Unit,
   modifier: Modifier = Modifier,
 ) {
@@ -134,12 +134,12 @@ internal fun SpotDetailContent(
       }
     }
 
-    if (isWatched) {
+    if (isInPermitZone) {
 
       ParkBuddyButton(label = "Park Here", onClick = onParkHere, modifier = Modifier.fillMaxWidth())
 
       Text(
-        text = "This street is in your watched zone",
+        text = "This street is in your permit zone",
         style = MaterialTheme.typography.labelSmall,
         color = SageGreen,
         modifier = Modifier.align(Alignment.CenterHorizontally),
@@ -183,11 +183,11 @@ internal val spot =
 @Preview(showBackground = true)
 @Composable
 private fun WatchedSpotDetailContentPreview() {
-  ParkBuddyTheme { SpotDetailContent(spot = spot, isWatched = true, onParkHere = {}) }
+  ParkBuddyTheme { SpotDetailContent(spot = spot, isInPermitZone = true, onParkHere = {}) }
 }
 
 @Preview(showBackground = true)
 @Composable
 private fun NonWatchedSpotDetailContentPreview() {
-  ParkBuddyTheme { SpotDetailContent(spot = spot, isWatched = false, onParkHere = {}) }
+  ParkBuddyTheme { SpotDetailContent(spot = spot, isInPermitZone = false, onParkHere = {}) }
 }

--- a/feature/reminders/src/main/java/dev/parkbuddy/feature/reminders/permitzone/AddReminderDialog.kt
+++ b/feature/reminders/src/main/java/dev/parkbuddy/feature/reminders/permitzone/AddReminderDialog.kt
@@ -1,4 +1,4 @@
-package dev.parkbuddy.feature.reminders.watchlist
+package dev.parkbuddy.feature.reminders.permitzone
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row

--- a/feature/reminders/src/main/java/dev/parkbuddy/feature/reminders/permitzone/PermitStreetItem.kt
+++ b/feature/reminders/src/main/java/dev/parkbuddy/feature/reminders/permitzone/PermitStreetItem.kt
@@ -1,4 +1,4 @@
-package dev.parkbuddy.feature.reminders.watchlist
+package dev.parkbuddy.feature.reminders.permitzone
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -21,7 +21,7 @@ import dev.bongballe.parkbuddy.model.ParkingSpot
 import dev.parkbuddy.core.ui.SquircleIcon
 
 @Composable
-internal fun WatchedStreetItem(spot: ParkingSpot) {
+internal fun PermitStreetItem(spot: ParkingSpot) {
   Card(
     modifier = Modifier.fillMaxWidth(),
     shape = MaterialTheme.shapes.medium,

--- a/feature/reminders/src/main/java/dev/parkbuddy/feature/reminders/permitzone/PermitZoneScreen.kt
+++ b/feature/reminders/src/main/java/dev/parkbuddy/feature/reminders/permitzone/PermitZoneScreen.kt
@@ -1,4 +1,4 @@
-package dev.parkbuddy.feature.reminders.watchlist
+package dev.parkbuddy.feature.reminders.permitzone
 
 import android.Manifest
 import android.app.AlarmManager
@@ -61,15 +61,15 @@ import kotlinx.datetime.LocalTime
 
 @OptIn(ExperimentalPermissionsApi::class)
 @Composable
-fun WatchlistScreen(
+fun PermitZoneScreen(
   modifier: Modifier = Modifier,
-  viewModel: WatchlistViewModel = metroViewModel(),
+  viewModel: PermitZoneViewModel = metroViewModel(),
 ) {
   val context = LocalContext.current
   val availableZones by viewModel.availableZones.collectAsState()
   val selectedZone by viewModel.selectedZone.collectAsState()
-  val watchedSpotCount by viewModel.watchedSpotCount.collectAsState()
-  val watchedSpots by viewModel.watchedSpots.collectAsState()
+  val permitSpotCount by viewModel.permitSpotCount.collectAsState()
+  val permitSpots by viewModel.permitSpots.collectAsState()
   val reminders by viewModel.reminders.collectAsState()
   val isZonePickerExpanded by viewModel.isZonePickerExpanded.collectAsState()
 
@@ -136,11 +136,11 @@ fun WatchlistScreen(
     )
   }
 
-  WatchlistContent(
+  PermitZoneContent(
     availableZones = availableZones,
     selectedZone = selectedZone,
-    watchedSpotCount = watchedSpotCount,
-    watchedSpots = watchedSpots,
+    permitSpotCount = permitSpotCount,
+    permitSpots = permitSpots,
     reminders = reminders,
     isZonePickerExpanded = isZonePickerExpanded,
     onZonePickerExpandedChange = viewModel::setZonePickerExpanded,
@@ -153,11 +153,11 @@ fun WatchlistScreen(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-internal fun WatchlistContent(
+internal fun PermitZoneContent(
   availableZones: List<String>,
   selectedZone: String?,
-  watchedSpotCount: Int,
-  watchedSpots: List<ParkingSpot>,
+  permitSpotCount: Int,
+  permitSpots: List<ParkingSpot>,
   reminders: List<ReminderMinutes>,
   isZonePickerExpanded: Boolean,
   onZonePickerExpandedChange: (Boolean) -> Unit,
@@ -194,7 +194,7 @@ internal fun WatchlistContent(
         ZoneSelectorCard(
           availableZones = availableZones,
           selectedZone = selectedZone,
-          watchedSpotCount = watchedSpotCount,
+          permitSpotCount = permitSpotCount,
           isExpanded = isZonePickerExpanded,
           onExpandedChange = onZonePickerExpandedChange,
           onZoneSelected = onZoneSelected,
@@ -230,14 +230,14 @@ internal fun WatchlistContent(
 
         item {
           Text(
-            "WATCHED STREETS",
+            "PERMIT STREETS",
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             style = MaterialTheme.typography.titleMedium,
             modifier = Modifier.padding(top = 16.dp),
           )
         }
 
-        items(watchedSpots) { spot -> WatchedStreetItem(spot = spot) }
+        items(permitSpots) { spot -> PermitStreetItem(spot = spot) }
       }
 
       if (selectedZone == null) {
@@ -270,7 +270,7 @@ internal fun WatchlistContent(
               Text(
                 text =
                   "Choose your residential parking permit zone to automatically " +
-                    "watch all streets in your area and receive cleaning reminders.",
+                    "manage all streets in your area and receive street cleaning reminders.",
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 textAlign = TextAlign.Center,
@@ -286,7 +286,7 @@ internal fun WatchlistContent(
 
 @Preview(showBackground = true)
 @Composable
-private fun WatchlistContentPreview() {
+private fun PermitZoneContentPreview() {
   val sampleSpot =
     ParkingSpot(
       objectId = "1",
@@ -319,11 +319,11 @@ private fun WatchlistContentPreview() {
     )
 
   ParkBuddyTheme {
-    WatchlistContent(
+    PermitZoneContent(
       availableZones = listOf("A", "B", "C"),
       selectedZone = "A",
-      watchedSpotCount = 5,
-      watchedSpots = listOf(sampleSpot),
+      permitSpotCount = 5,
+      permitSpots = listOf(sampleSpot),
       reminders = listOf(ReminderMinutes(60)),
       isZonePickerExpanded = false,
       onZonePickerExpandedChange = {},
@@ -336,13 +336,13 @@ private fun WatchlistContentPreview() {
 
 @Preview(showBackground = true)
 @Composable
-private fun WatchlistContentEmptyPreview() {
+private fun PermitZoneContentEmptyPreview() {
   ParkBuddyTheme {
-    WatchlistContent(
+    PermitZoneContent(
       availableZones = listOf("A", "B", "C"),
       selectedZone = null,
-      watchedSpotCount = 0,
-      watchedSpots = emptyList(),
+      permitSpotCount = 0,
+      permitSpots = emptyList(),
       reminders = emptyList(),
       isZonePickerExpanded = false,
       onZonePickerExpandedChange = {},

--- a/feature/reminders/src/main/java/dev/parkbuddy/feature/reminders/permitzone/PermitZoneViewModel.kt
+++ b/feature/reminders/src/main/java/dev/parkbuddy/feature/reminders/permitzone/PermitZoneViewModel.kt
@@ -1,4 +1,4 @@
-package dev.parkbuddy.feature.reminders.watchlist
+package dev.parkbuddy.feature.reminders.permitzone
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -22,9 +22,9 @@ import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @ContributesIntoMap(AppScope::class)
-@ViewModelKey(WatchlistViewModel::class)
+@ViewModelKey(PermitZoneViewModel::class)
 @Inject
-class WatchlistViewModel(
+class PermitZoneViewModel(
   private val repository: ParkingRepository,
   private val reminderRepository: ReminderRepository,
 ) : ViewModel() {
@@ -47,7 +47,7 @@ class WatchlistViewModel(
         initialValue = null,
       )
 
-  val watchedSpotCount: StateFlow<Int> =
+  val permitSpotCount: StateFlow<Int> =
     selectedZone
       .flatMapLatest { zone -> if (zone == null) flowOf(0) else repository.countSpotsByZone(zone) }
       .stateIn(
@@ -56,7 +56,7 @@ class WatchlistViewModel(
         initialValue = 0,
       )
 
-  val watchedSpots: StateFlow<List<ParkingSpot>> =
+  val permitSpots: StateFlow<List<ParkingSpot>> =
     selectedZone
       .flatMapLatest { zone ->
         if (zone == null) flowOf(emptyList()) else repository.getSpotsByZone(zone)

--- a/feature/reminders/src/main/java/dev/parkbuddy/feature/reminders/permitzone/ReminderItem.kt
+++ b/feature/reminders/src/main/java/dev/parkbuddy/feature/reminders/permitzone/ReminderItem.kt
@@ -1,4 +1,4 @@
-package dev.parkbuddy.feature.reminders.watchlist
+package dev.parkbuddy.feature.reminders.permitzone
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement

--- a/feature/reminders/src/main/java/dev/parkbuddy/feature/reminders/permitzone/ZoneSelectorCard.kt
+++ b/feature/reminders/src/main/java/dev/parkbuddy/feature/reminders/permitzone/ZoneSelectorCard.kt
@@ -1,4 +1,4 @@
-package dev.parkbuddy.feature.reminders.watchlist
+package dev.parkbuddy.feature.reminders.permitzone
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -26,7 +26,7 @@ import androidx.compose.ui.unit.dp
 internal fun ZoneSelectorCard(
   availableZones: List<String>,
   selectedZone: String?,
-  watchedSpotCount: Int,
+  permitSpotCount: Int,
   isExpanded: Boolean,
   onExpandedChange: (Boolean) -> Unit,
   onZoneSelected: (String?) -> Unit,
@@ -73,7 +73,7 @@ internal fun ZoneSelectorCard(
       if (selectedZone != null) {
         Spacer(modifier = Modifier.height(12.dp))
         Text(
-          text = "$watchedSpotCount streets auto-watched",
+          text = "$permitSpotCount streets in your permit zone",
           style = MaterialTheme.typography.bodyMedium,
           color = MaterialTheme.colorScheme.onPrimaryContainer,
         )

--- a/feature/reminders/src/test/java/dev/parkbuddy/feature/reminders/permitzone/PermitZoneViewModelTest.kt
+++ b/feature/reminders/src/test/java/dev/parkbuddy/feature/reminders/permitzone/PermitZoneViewModelTest.kt
@@ -1,4 +1,4 @@
-package dev.parkbuddy.feature.reminders.watchlist
+package dev.parkbuddy.feature.reminders.permitzone
 
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
@@ -19,17 +19,17 @@ import org.robolectric.RobolectricTestRunner
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(RobolectricTestRunner::class)
-class WatchlistViewModelTest {
+class PermitZoneViewModelTest {
 
   private class TestContext {
     val parkingRepository = FakeParkingRepository()
     val reminderRepository = FakeReminderRepository()
 
     fun createViewModel() =
-      WatchlistViewModel(repository = parkingRepository, reminderRepository = reminderRepository)
+      PermitZoneViewModel(repository = parkingRepository, reminderRepository = reminderRepository)
   }
 
-  private fun runWatchlistTest(
+  private fun runPermitZoneTest(
     dispatcher: TestDispatcher = UnconfinedTestDispatcher(),
     block: suspend TestScope.(TestContext) -> Unit,
   ) =
@@ -44,7 +44,7 @@ class WatchlistViewModelTest {
 
   @Test
   fun `selectZone updates repository and adds default reminders if empty`() =
-    runWatchlistTest { context ->
+    runPermitZoneTest { context ->
       val viewModel = context.createViewModel()
       viewModel.selectZone("A")
 


### PR DESCRIPTION
This is in preparation to expand the app's utility beyond just tracking street cleaning in the user's permit zone ("watched" streets). The app should now detect parking on any street with restrictions (like 2-hour limits) and provide appropriate notifications.

- Rename Variables & Classes: Transition from "Watched" to "PermitZone"
- Update UI Strings: Change "Watched Streets" to "My Permit Zone" in the WatchlistScreen (to be renamed PermitZoneScreen) and ZoneSelectorCard.
- Data Model Update: Add a ParkingType enum (PERMIT, TIMED, UNRESTRICTED) to the ParkedLocation model to persist the context of the parking session.